### PR TITLE
Fix forced_role when volunteers sign up players; update signup emails

### DIFF
--- a/app/templates/jinja2/email/signup.html
+++ b/app/templates/jinja2/email/signup.html
@@ -16,23 +16,14 @@
   <![endif]-->
 </head>
 <body>
-<p>Thank you for signing up for Humans vs Zombies Spring 2018!</p>
+<p>Thank you for signing up for Humans vs Zombies Fall 2018!</p>
 <p><a href="{{ site_url }}{{ url('signup', args=[signup_invite.id]) }}">Please finish signing up to our website here.</a></p>
-<p>Make sure to read and agree to the waiver, read the rules of the game, and print out your player card. (Our website is currently being polished, some of these features will be available by the end of this week).</p>
-<p>The game will begin on <strong>Monday, July 9th @ 12:00 AM</strong>. If you have any friends who would like to the join, please send them to one of our signup booths before Friday, July 6th @ 5 PM. Or they can contact us at uwhumansvszombies@gmail.com with their email.</p>
-<p>At <strong>5:00 PM on Sunday, July 8th</strong> in STC on UWaterloo Campus, we will be hosting a practice mission to practice for the weeklong game. It will help introduce rules, have a little bit of fun and get the hang of the game. Please bring a bandana and any socks or blasters to use.</p>
-<p>At <strong>11:00 PM on Sunday, July 8th</strong>, you will receive an email whether you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please check the box when you are making your account.</p>
-<p>Please join our <a href="https://www.facebook.com/groups/uwhvz/">Facebook Group</a> to easily access updates. Our website will also display announcements and mission details for the day. Each night before an email will be sent out about the agenda for the next day, including times for supply drops, mini-missions and Main Missions. Main Mission details will be emailed an hour before Main Mission begins.</p>
+<p>Make sure to read and agree to the waiver, as well as read the rules of the game.</p>
+<p>The game will begin on <strong>Monday, November 5th @ 12:00 AM</strong>. If you have any friends who have never played before and would like to join, please send them to one of our signup booths before Friday, November 2nd @ 5 PM. Alternatively, they can contact us at <a href="mailto:uwhumansvszombies@gmail.com">uwhumansvszombies@gmail.com</a> via email.</p>
+<p>At <strong>5:00 PM on Sunday, November 4th</strong> in STC on the UWaterloo Campus, we will be hosting a practice mission to practice for the weeklong game. It will help introduce rules, have a little bit of fun and get the hang of the game. Please bring a bandana and any socks or blasters to use.</p>
+<p>At <strong>11:00 PM on Sunday, November 4th</strong>, you will receive an email whether you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please check the box when you are signing up for the game.</p>
+<p>Please join our <a href="https://www.facebook.com/groups/uwhvz/">Facebook Group</a> to easily access updates. Our website will also display announcements and mission details for the day. Each night before, an email will be sent out about the agenda for the next day, including times for supply drops, mini-missions and Main Missions. Main Mission details will be emailed an hour before the Main Mission begins.</p>
 <p>Additional important information will be sent over twitter through <a href="https://twitter.com/hvzalertsystem">@HVZAlertSystem</a>. You can get the tweets texted to you by texting “follow <span class="citation" data-cites="HVZAlertSystem">@HVZAlertSystem</span>” to the number 21212.</p>
-<p>A couple new mechanics for Humans have been introduced including <strong>FACTIONS</strong>. Factions are human teams that give special perks to their members, missions will help or hinder your faction. Every human player must now wear two bandanas on the same arm. The moderators will provide you a bandana of your faction’s colour when you sign up for a faction. <strong>Factions are Human Team Only.</strong></p>
-<p><a href="https://imgur.com/a/hDoz6tf"><strong>Here is a list of factions.</strong></a></p>
-<p>You may sign up for a faction by:</p>
-<ul>
-<li>Going back to a sign up booth</li>
-<li>Our Practice Mission on Sunday</li>
-<li>Or by asking a Moderator during the weeklong game (This includes, mini-mission, @ the shop, supply drops)</li>
-</ul>
-<p><strong>You don’t need to choose a faction right away or at all.</strong></p>
 <p>If you need to rent a blaster from the Humans vs Zombie Society, you can email us at uwhumansvszombies@gmail.com for more information.</p>
 <p><a href="https://docs.google.com/document/d/1qWEV0cvqfqg9o8IvreCV2yV52SDmmdyV562-XO9Hl84/edit"><strong>You can find all rule changes and additions here.</strong></a></p>
 </body>

--- a/app/templates/jinja2/email/signup.md
+++ b/app/templates/jinja2/email/signup.md
@@ -1,56 +1,35 @@
-Thank you for signing up for Humans vs Zombies Spring 2018!
+Thank you for signing up for Humans vs Zombies Fall 2018!
 
 [Please finish signing up to our website
 here.]({{ site_url }}{{ url('signup', args=[signup_invite.id]) }})
 
-Make sure to read and agree to the waiver, read the rules of the game,
-and print out your player card. (Our website is currently being
-polished, some of these features will be available by the end of this
-week).
+Make sure to read and agree to the waiver, as well as read the rules of the game.
 
-The game will begin on **Monday, July 9th @ 12:00 AM**. If you have any
-friends who would like to the join, please send them to one of our
-signup booths before Friday, July 6th @ 5 PM. Or they can contact us at
-uwhumansvszombies\@gmail.com with their email.
+The game will begin on **Monday, November 5th @ 12:00 AM**. If you have any
+friends who have never played before and would like to join, please send them to one of our
+signup booths before Friday, November 2nd @ 5 PM. Alternatively, they can contact us at
+[uwhumansvszombies\@gmail.com](mailto:uwhumansvszombies@gmail.com) via email.
 
-At **5:00 PM on Sunday, July 8th** in STC on UWaterloo Campus, we will
+At **5:00 PM on Sunday, November 4th** in STC on the UWaterloo Campus, we will
 be hosting a practice mission to practice for the weeklong game. It will
 help introduce rules, have a little bit of fun and get the hang of the
 game. Please bring a bandana and any socks or blasters to use.
 
-At **11:00 PM on Sunday, July 8th**, you will receive an email whether
+At **11:00 PM on Sunday, November 4th**, you will receive an email whether
 you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please
-check the box when you are making your account.
+check the box when you are signing up for the game.
 
 Please join our [Facebook Group](https://www.facebook.com/groups/uwhvz/)
 to easily access updates. Our website will also display announcements
-and mission details for the day. Each night before an email will be sent
+and mission details for the day. Each night before, an email will be sent
 out about the agenda for the next day, including times for supply drops,
 mini-missions and Main Missions. Main Mission details will be emailed an
-hour before Main Mission begins.
+hour before the Main Mission begins.
 
 Additional important information will be sent over twitter through
 [\@HVZAlertSystem](https://twitter.com/hvzalertsystem). You can get the
 tweets texted to you by texting "follow @HVZAlertSystem" to the number
 21212.
-
-A couple new mechanics for Humans have been introduced including
-**FACTIONS**. Factions are human teams that give special perks to their
-members, missions will help or hinder your faction. Every human player
-must now wear two bandanas on the same arm. The moderators will provide
-you a bandana of your faction's colour when you sign up for a faction.
-**Factions are Human Team Only.**
-
-[**Here is a list of factions.**](https://imgur.com/a/hDoz6tf)
-
-You may sign up for a faction by:
-
--   Going back to a sign up booth
--   Our Practice Mission on Sunday
--   Or by asking a Moderator during the weeklong game (This includes,
-    mini-mission, @ the shop, supply drops)
-
-**You don't need to choose a faction right away or at all.**
 
 If you need to rent a blaster from the Humans vs Zombie Society, you can
 email us at uwhumansvszombies\@gmail.com for more information.

--- a/app/templates/jinja2/email/signup.txt
+++ b/app/templates/jinja2/email/signup.txt
@@ -1,4 +1,4 @@
-Thank you for signing up for Humans vs Zombies Spring 2018!
+Thank you for signing up for Humans vs Zombies Fall 2018!
 
 Please finish signing up to our website here: {{ site_url }}{{ url('signup', args=[signup_invite.id]) }}
 
@@ -7,19 +7,19 @@ and print out your player card. (Our website is currently being
 polished, some of these features will be available by the end of this
 week).
 
-The game will begin on Monday, July 9th @ 12:00 AM. If you have any
+The game will begin on Monday, November 5th @ 12:00 AM. If you have any
 friends who would like to the join, please send them to one of our
-signup booths before Friday, July 6th @ 5 PM. Or they can contact us at
+signup booths before Friday, November 2nd @ 5:00 PM. Or they can contact us at
 uwhumansvszombies@gmail.com with their email.
 
-At 5:00 PM on Sunday, July 8th in STC on UWaterloo Campus, we will
+At 5:00 PM on Sunday, November 4th in STC on UWaterloo Campus, we will
 be hosting a practice mission to practice for the weeklong game. It will
 help introduce rules, have a little bit of fun and get the hang of the
 game. Please bring a bandana and any socks or blasters to use.
 
-At 11:00 PM on Sunday, July 8th, you will receive an email whether
+At 11:00 PM on Sunday, November 4th, you will receive an email whether
 you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please
-check the box when you are making your account.
+check the box when you are making your account and signing up for the game.
 
 Please join our Facebook Group: https://www.facebook.com/groups/uwhvz/
 to easily access updates. Our website will also display announcements
@@ -32,23 +32,6 @@ Additional important information will be sent over twitter through
 @HVZAlertSystem (https://twitter.com/hvzalertsystem). You can get the
 tweets texted to you by texting "follow @HVZAlertSystem" to the number
 21212.
-
-A couple new mechanics for Humans have been introduced including
-FACTIONS. Factions are human teams that give special perks to their
-members, missions will help or hinder your faction. Every human player
-must now wear two bandanas on the same arm. The moderators will provide
-you a bandana of your faction's colour when you sign up for a faction.
-Factions are Human Team Only.
-
-Here is a list of factions: https://imgur.com/a/hDoz6tf
-
-You may sign up for a faction by:
--   Going back to a sign up booth
--   Our Practice Mission on Sunday
--   Or by asking a Moderator during the weeklong game (This includes,
-    mini-mission, @ the shop, supply drops)
-
-You don't need to choose a faction right away or at all.
 
 If you need to rent a blaster from the Humans vs Zombie Society, you can
 email us at uwhumansvszombies@gmail.com for more information.

--- a/app/templates/jinja2/email/signup_reminder.md
+++ b/app/templates/jinja2/email/signup_reminder.md
@@ -1,5 +1,5 @@
 You're receiving this email because you've requested to sign up for
-the UW Humans vs Zombies Spring 2018 game but are **not yet eligible to
+the UW Humans vs Zombies Fall 2018 game but are **not yet eligible to
 play.**
 
 This will take 30 seconds. Please finish signing up here: {{ signup_url }}.

--- a/app/views/signup.py
+++ b/app/views/signup.py
@@ -74,7 +74,12 @@ class GameSignupView(View):
 
     def post(self, request):
         game = most_recent_game()
-        forced_role = SignupInvite.objects.filter(used_at__isnull=False, email=request.user.email).get().player_role
+
+        try:
+            forced_role = SignupInvite.objects.filter(used_at__isnull=False, email=request.user.email).get().player_role
+        except DoesNotExist:
+            forced_role = None
+        
         in_oz_pool = request.POST.get('is_oz', 'off') == 'on'
         has_signed_waiver = request.POST.get('accept_waiver', 'off') == 'on'
 


### PR DESCRIPTION
## Checklist
- catches `DoesNotExist` exceptions that occur whenever a volunteer signs up a player (since `forced_role` is a mod-only feature but we keep trying to `.get()` it anyways)
- update signup email text