### PR TITLE
Add http in front of signup invite urls

### DIFF
--- a/app/migrations/0016_auto_20181029_0555.py
+++ b/app/migrations/0016_auto_20181029_0555.py
@@ -4,7 +4,7 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
-def add_game_to_missions_and_annoucements(apps, schema_editor):
+def add_game_to_missions_and_announcements(apps, schema_editor):
     Game = apps.get_model('app', 'Game')
     MissionPage = apps.get_model('app', 'MissionPage')
     AnnouncementPage = apps.get_model('app', 'AnnouncementPage')
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=True),
         ),
         migrations.RunPython(
-            code=add_game_to_missions_and_annoucements,
+            code=add_game_to_missions_and_announcements,
             reverse_code=migrations.RunPython.noop,
         ),
     ]

--- a/app/templates/jinja2/email/signup.html
+++ b/app/templates/jinja2/email/signup.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <p>Thank you for signing up for Humans vs Zombies Fall 2018!</p>
-<p><a href="{{ site_url }}{{ url('signup', args=[signup_invite.id]) }}">Please finish signing up to our website here.</a></p>
+<p><a href="https://{{ site_url }}{{ url('signup', args=[signup_invite.id]) }}">Please finish signing up to our website here.</a></p>
 <p>Make sure to read and agree to the waiver, as well as read the rules of the game.</p>
 <p>The game will begin on <strong>Monday, November 5th @ 12:00 AM</strong>. If you have any friends who have never played before and would like to join, please send them to one of our signup booths before Friday, November 2nd @ 5 PM. Alternatively, they can contact us at <a href="mailto:uwhumansvszombies@gmail.com">uwhumansvszombies@gmail.com</a> via email.</p>
 <p>At <strong>5:00 PM on Sunday, November 4th</strong> in STC on the UWaterloo Campus, we will be hosting a practice mission to practice for the weeklong game. It will help introduce rules, have a little bit of fun and get the hang of the game. Please bring a bandana and any socks or blasters to use.</p>

--- a/app/templates/jinja2/email/signup.md
+++ b/app/templates/jinja2/email/signup.md
@@ -1,7 +1,7 @@
 Thank you for signing up for Humans vs Zombies Fall 2018!
 
 [Please finish signing up to our website
-here.]({{ site_url }}{{ url('signup', args=[signup_invite.id]) }})
+here.](https://{{ site_url }}{{ url('signup', args=[signup_invite.id]) }})
 
 Make sure to read and agree to the waiver, as well as read the rules of the game.
 

--- a/app/templates/jinja2/email/signup.txt
+++ b/app/templates/jinja2/email/signup.txt
@@ -1,6 +1,6 @@
 Thank you for signing up for Humans vs Zombies Fall 2018!
 
-Please finish signing up to our website here: {{ site_url }}{{ url('signup', args=[signup_invite.id]) }}
+Please finish signing up to our website here: https://{{ site_url }}{{ url('signup', args=[signup_invite.id]) }}
 
 Make sure to read and agree to the waiver, read the rules of the game,
 and print out your player card. (Our website is currently being


### PR DESCRIPTION
## Checklist
- fixes urls in signup emails to be clickable properly (right now it's valid, just need to copy and paste though)
- fix typo in migration code (@tso pls)