### PR TITLE
remove specific content from signup-related emails from repo tracking

### DIFF
--- a/app/templates/jinja2/email/signup.html
+++ b/app/templates/jinja2/email/signup.html
@@ -18,13 +18,5 @@
 <body>
 <p>Thank you for signing up for Humans vs Zombies {{ game }}!</p>
 <p><a href="{{ site_url }}{{ url('signup', args=[signup_invite.id]) }}">Please finish signing up to our website here.</a></p>
-<p>Make sure to read and agree to the waiver, as well as read the rules of the game.</p>
-<p>The game will begin on <strong>Monday, November 5th @ 12:00 AM</strong>. If you have any friends who have never played before and would like to join, please send them to one of our signup booths before Friday, November 2nd @ 5 PM. Alternatively, they can contact us at <a href="mailto:uwhumansvszombies@gmail.com">uwhumansvszombies@gmail.com</a> via email.</p>
-<p>At <strong>5:00 PM on Sunday, November 4th</strong> in STC on the UWaterloo Campus, we will be hosting a practice mission to practice for the weeklong game. It will help introduce rules, have a little bit of fun and get the hang of the game. Please bring a bandana and any socks or blasters to use.</p>
-<p>At <strong>11:00 PM on Sunday, November 4th</strong>, you will receive an email whether you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please check the box when you are signing up for the game.</p>
-<p>Please join our <a href="https://www.facebook.com/groups/uwhvz/">Facebook Group</a> to easily access updates. Our website will also display announcements and mission details for the day. Each night before, an email will be sent out about the agenda for the next day, including times for supply drops, mini-missions and Main Missions. Main Mission details will be emailed an hour before the Main Mission begins.</p>
-<p>Additional important information will be sent over twitter through <a href="https://twitter.com/hvzalertsystem">@HVZAlertSystem</a>. You can get the tweets texted to you by texting “follow <span class="citation" data-cites="HVZAlertSystem">@HVZAlertSystem</span>” to the number 21212.</p>
-<p>If you need to rent a blaster from the Humans vs Zombie Society, you can email us at uwhumansvszombies@gmail.com for more information.</p>
-<p><a href="https://docs.google.com/document/d/1qWEV0cvqfqg9o8IvreCV2yV52SDmmdyV562-XO9Hl84/edit"><strong>You can find all rule changes and additions here.</strong></a></p>
 </body>
 </html>

--- a/app/templates/jinja2/email/signup.md
+++ b/app/templates/jinja2/email/signup.md
@@ -2,37 +2,3 @@ Thank you for signing up for Humans vs Zombies {{ game }}!
 
 [Please finish signing up to our website
 here.]({{ site_url }}{{ url('signup', args=[signup_invite.id]) }})
-
-Make sure to read and agree to the waiver, as well as read the rules of the game.
-
-The game will begin on **Monday, November 5th @ 12:00 AM**. If you have any
-friends who have never played before and would like to join, please send them to one of our
-signup booths before Friday, November 2nd @ 5 PM. Alternatively, they can contact us at
-[uwhumansvszombies\@gmail.com](mailto:uwhumansvszombies@gmail.com) via email.
-
-At **5:00 PM on Sunday, November 4th** in STC on the UWaterloo Campus, we will
-be hosting a practice mission to practice for the weeklong game. It will
-help introduce rules, have a little bit of fun and get the hang of the
-game. Please bring a bandana and any socks or blasters to use.
-
-At **11:00 PM on Sunday, November 4th**, you will receive an email whether
-you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please
-check the box when you are signing up for the game.
-
-Please join our [Facebook Group](https://www.facebook.com/groups/uwhvz/)
-to easily access updates. Our website will also display announcements
-and mission details for the day. Each night before, an email will be sent
-out about the agenda for the next day, including times for supply drops,
-mini-missions and Main Missions. Main Mission details will be emailed an
-hour before the Main Mission begins.
-
-Additional important information will be sent over twitter through
-[\@HVZAlertSystem](https://twitter.com/hvzalertsystem). You can get the
-tweets texted to you by texting "follow @HVZAlertSystem" to the number
-21212.
-
-If you need to rent a blaster from the Humans vs Zombie Society, you can
-email us at uwhumansvszombies\@gmail.com for more information.
-
-[**You can find all rule changes and additions
-here.**](https://docs.google.com/document/d/1qWEV0cvqfqg9o8IvreCV2yV52SDmmdyV562-XO9Hl84/edit)

--- a/app/templates/jinja2/email/signup.txt
+++ b/app/templates/jinja2/email/signup.txt
@@ -1,39 +1,3 @@
 Thank you for signing up for Humans vs Zombies {{ game }}!
 
 Please finish signing up to our website here: {{ site_url }}{{ url('signup', args=[signup_invite.id]) }}
-
-Make sure to read and agree to the waiver, read the rules of the game,
-and print out your player card. (Our website is currently being
-polished, some of these features will be available by the end of this
-week).
-
-The game will begin on Monday, November 5th @ 12:00 AM. If you have any
-friends who would like to the join, please send them to one of our
-signup booths before Friday, November 2nd @ 5:00 PM. Or they can contact us at
-uwhumansvszombies@gmail.com with their email.
-
-At 5:00 PM on Sunday, November 4th in STC on UWaterloo Campus, we will
-be hosting a practice mission to practice for the weeklong game. It will
-help introduce rules, have a little bit of fun and get the hang of the
-game. Please bring a bandana and any socks or blasters to use.
-
-At 11:00 PM on Sunday, November 4th, you will receive an email whether
-you are a HUMAN or a ZOMBIE. If you would like to be a zombie, please
-check the box when you are making your account and signing up for the game.
-
-Please join our Facebook Group: https://www.facebook.com/groups/uwhvz/
-to easily access updates. Our website will also display announcements
-and mission details for the day. Each night before an email will be sent
-out about the agenda for the next day, including times for supply drops,
-mini-missions and Main Missions. Main Mission details will be emailed an
-hour before Main Mission begins.
-
-Additional important information will be sent over twitter through
-@HVZAlertSystem (https://twitter.com/hvzalertsystem). You can get the
-tweets texted to you by texting "follow @HVZAlertSystem" to the number
-21212.
-
-If you need to rent a blaster from the Humans vs Zombie Society, you can
-email us at uwhumansvszombies@gmail.com for more information.
-
-You can find all rule changes and additions here: https://docs.google.com/document/d/1qWEV0cvqfqg9o8IvreCV2yV52SDmmdyV562-XO9Hl84/edit

--- a/app/templates/jinja2/email/signup_reminder.html
+++ b/app/templates/jinja2/email/signup_reminder.html
@@ -18,7 +18,7 @@
 <body>
 <p>You’re receiving this email because you’ve requested to sign up for the UW Humans vs Zombies {{ game }} game but are <strong>not yet eligible to play.</strong></p>
 <p>This will take 30 seconds. Please finish signing up here: {{ signup_url }}.</p>
-<p>This must be done before 11:00PM tonight.</p>
-<p>Sincerely, The UW HvZ Website</p>
+<p>Sincerely,</p>
+<p> The UW HvZ Website</p>
 </body>
 </html>

--- a/app/templates/jinja2/email/signup_reminder.md
+++ b/app/templates/jinja2/email/signup_reminder.md
@@ -2,7 +2,5 @@ You're receiving this email because you've requested to sign up for the UW Human
 
 This will take 30 seconds. Please finish signing up here: {{ signup_url }}.
 
-This must be done before 11:00PM tonight.
-
 Sincerely,
 The UW HvZ Website

--- a/app/templates/jinja2/email/signup_reminder.txt
+++ b/app/templates/jinja2/email/signup_reminder.txt
@@ -2,6 +2,5 @@ You're receiving this email because you've requested to sign up for the UW Human
 
 This will take 30 seconds. Please finish signing up here: {{ signup_url }}.
 
-This must be done before 11:00PM tonight.
-
-Sincerely, The UW HvZ Website
+Sincerely, 
+The UW HvZ Website


### PR DESCRIPTION
Since the (eventual) plan is to transition to the point where emails can be changed by moderators, caching any extra content to the repo should not be necessary. However, we do use the signup emails as a part of testing, so only generic email content containing a link to the website will be left behind for testing purposes only. 

Also, the email content changes too often between semesters to keep it updated, so any further changes to content that isn't related to linking the website itself should be done to production only.